### PR TITLE
fix: error logs are showing as info logs

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"runtime/debug"
 
-	"github.com/go-chi/chi/middleware"
+	"github.com/rs/zerolog"
 )
 
 // APIError is a struct describing an error
@@ -33,9 +33,10 @@ func Recoverer(env string) func(http.Handler) http.Handler {
 			defer func() {
 				if rvr := recover(); rvr != nil && rvr != http.ErrAbortHandler {
 
-					logEntry := middleware.GetLogEntry(r)
-					if logEntry != nil {
-						logEntry.Panic(rvr, debug.Stack())
+					log := zerolog.Ctx(r.Context())
+					if log != nil {
+						err := rvr.(error) // kill yourself
+						log.Err(err).Msg("")
 					} else {
 						fmt.Fprintf(os.Stderr, "Panic: %+v\n", rvr)
 					}

--- a/middleware.go
+++ b/middleware.go
@@ -22,7 +22,9 @@ import (
 func DefaultMiddleware(router *chi.Mux, appEnv string, log zerolog.Logger) {
 	router.Use(middleware.RequestID)
 	router.Use(middleware.RealIP)
-	router.Use(ZeroMiddleware(log, appEnv))
+	router.Use(AttachLogger(log))
+	router.Use(RequestLogger())
+	router.Use(ResponseLogger())
 	router.Use(Recoverer(appEnv))
 	router.Use(middleware.RedirectSlashes)
 	router.Use(middleware.Compress(5))

--- a/responses.go
+++ b/responses.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/go-chi/chi/middleware"
 	"github.com/rs/zerolog"
 )
 
@@ -13,14 +12,17 @@ import (
 // sure what deserves to be logged gets logged
 func SendJSON(r *http.Request, w http.ResponseWriter, code int, v interface{}) {
 	raw, _ := json.Marshal(v)
-	entry := middleware.GetLogEntry(r).(*ZeroLogEntry)
+	log := zerolog.Ctx(r.Context())
 
 	// log API responses
 	if v != nil {
-		entry.Log.UpdateContext(func(ctx zerolog.Context) zerolog.Context {
+		log.UpdateContext(func(ctx zerolog.Context) zerolog.Context {
 			return ctx.RawJSON("response", CompactJSON(raw))
 		})
 	}
+
+	// Send the actual logs
+	log.Info().Msg("")
 
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.Header().Set("X-Content-Type-Options", "nosniff")


### PR DESCRIPTION
This is primarily due to how we integrated with go-chi RequestLogger. Our Write implementation always uses Info log level. So I switched to using my own log middleware as RequestLogger doesn't give much flexibility.